### PR TITLE
Fix typo in action.yml.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: 'lock'
   color: 'yellow'
 inputs:
-  ssm-paths:
+  ssm-path:
     description: 'required. AWS SSM path for parameters eg. `/ssm/parameter`'
     required: true
   format:


### PR DESCRIPTION
The document and the implementation of the action accesses with the name `ssm-path`, but `action.yml` declares it with a name `ssm-paths`. So that the github action warns a valid parameter as unexpected input.