### PR TITLE
chore(actions): update environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: '(optional) Specifies if the decryption should be performed on SSM parameters'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'


### PR DESCRIPTION
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following deprecation warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12.